### PR TITLE
Update kenlm to 0.1.20220713 to make it work on Python 3.10

### DIFF
--- a/deeppavlov/requirements/kenlm.txt
+++ b/deeppavlov/requirements/kenlm.txt
@@ -1,1 +1,1 @@
-git+https://github.com/kpu/kenlm.git@96d303cfb1a0c21b8f060dbad640d7ab301c019a#egg=kenlm
+pypi-kenlm==0.1.20220713


### PR DESCRIPTION
Currently `python -m deeppavlov install levenshtein_corrector_ru` is failing on kenlm install in Python 3.10:

```
Collecting sortedcontainers==2.4.*
  Downloading sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Installing collected packages: sortedcontainers
Successfully installed sortedcontainers-2.4.0
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/home/idris/.pyenv/versions/3.10.4/bin/python -m pip install --upgrade pip' command.
Collecting sacremoses==0.0.53
  Downloading sacremoses-0.0.53.tar.gz (880 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 880.6/880.6 KB 4.0 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Requirement already satisfied: regex in /home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages (from sacremoses==0.0.53) (2022.6.2)
Requirement already satisfied: six in /home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages (from sacremoses==0.0.53) (1.16.0)
Requirement already satisfied: click in /home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages (from sacremoses==0.0.53) (8.1.3)
Requirement already satisfied: joblib in /home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages (from sacremoses==0.0.53) (1.1.0)
Requirement already satisfied: tqdm in /home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages (from sacremoses==0.0.53) (4.64.0)
Building wheels for collected packages: sacremoses
  Building wheel for sacremoses (setup.py) ... done
  Created wheel for sacremoses: filename=sacremoses-0.0.53-py3-none-any.whl size=895260 sha256=be2d2a18d9babc5f67f53173fd2459434d7f2f1a95c7c9ad171c781d24c967ce
  Stored in directory: /home/idris/.cache/pip/wheels/00/24/97/a2ea5324f36bc626e1ea0267f33db6aa80d157ee977e9e42fb
Successfully built sacremoses
Installing collected packages: sacremoses
Successfully installed sacremoses-0.0.53
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/home/idris/.pyenv/versions/3.10.4/bin/python -m pip install --upgrade pip' command.
Collecting pypi-kenlm==0.1.20210121
  Downloading pypi-kenlm-0.1.20210121.tar.gz (253 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 254.0/254.0 KB 1.6 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: pypi-kenlm
  Building wheel for pypi-kenlm (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      running bdist_wheel
      running build
      running build_ext
      building 'kenlm' extension
      creating build
      creating build/temp.linux-x86_64-3.10
      creating build/temp.linux-x86_64-3.10/lm
      creating build/temp.linux-x86_64-3.10/python
      creating build/temp.linux-x86_64-3.10/util
      creating build/temp.linux-x86_64-3.10/util/double-conversion
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/bhiksha.cc -o build/temp.linux-x86_64-3.10/lm/bhiksha.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/binary_format.cc -o build/temp.linux-x86_64-3.10/lm/binary_format.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/config.cc -o build/temp.linux-x86_64-3.10/lm/config.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/lm_exception.cc -o build/temp.linux-x86_64-3.10/lm/lm_exception.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/model.cc -o build/temp.linux-x86_64-3.10/lm/model.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/quantize.cc -o build/temp.linux-x86_64-3.10/lm/quantize.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/read_arpa.cc -o build/temp.linux-x86_64-3.10/lm/read_arpa.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/search_hashed.cc -o build/temp.linux-x86_64-3.10/lm/search_hashed.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/search_trie.cc -o build/temp.linux-x86_64-3.10/lm/search_trie.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/sizes.cc -o build/temp.linux-x86_64-3.10/lm/sizes.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/trie.cc -o build/temp.linux-x86_64-3.10/lm/trie.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/trie_sort.cc -o build/temp.linux-x86_64-3.10/lm/trie_sort.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/value_build.cc -o build/temp.linux-x86_64-3.10/lm/value_build.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/virtual_interface.cc -o build/temp.linux-x86_64-3.10/lm/virtual_interface.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/vocab.cc -o build/temp.linux-x86_64-3.10/lm/vocab.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c python/kenlm.cpp -o build/temp.linux-x86_64-3.10/python/kenlm.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      python/kenlm.cpp: In function ‘PyObject* __Pyx_Coroutine_Send(PyObject*, PyObject*)’:
      python/kenlm.cpp:10162:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10162:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
                         _PyGen_yf
      python/kenlm.cpp:10167:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10167:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
                         _PyGen_yf
      python/kenlm.cpp: In function ‘PyObject* __Pyx_Generator_Next(PyObject*)’:
      python/kenlm.cpp:10251:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, NULL);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10251:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, NULL);
                         ^~~~~~~~~~~
                         _PyGen_yf
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pypi-kenlm
  Running setup.py clean for pypi-kenlm
Failed to build pypi-kenlm
Installing collected packages: pypi-kenlm
  Running setup.py install for pypi-kenlm ... error
  error: subprocess-exited-with-error

  × Running setup.py install for pypi-kenlm did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      running install
      running build
      running build_ext
      building 'kenlm' extension
      creating build
      creating build/temp.linux-x86_64-3.10
      creating build/temp.linux-x86_64-3.10/lm
      creating build/temp.linux-x86_64-3.10/python
      creating build/temp.linux-x86_64-3.10/util
      creating build/temp.linux-x86_64-3.10/util/double-conversion
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/bhiksha.cc -o build/temp.linux-x86_64-3.10/lm/bhiksha.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/binary_format.cc -o build/temp.linux-x86_64-3.10/lm/binary_format.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/config.cc -o build/temp.linux-x86_64-3.10/lm/config.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/lm_exception.cc -o build/temp.linux-x86_64-3.10/lm/lm_exception.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/model.cc -o build/temp.linux-x86_64-3.10/lm/model.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/quantize.cc -o build/temp.linux-x86_64-3.10/lm/quantize.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/read_arpa.cc -o build/temp.linux-x86_64-3.10/lm/read_arpa.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/search_hashed.cc -o build/temp.linux-x86_64-3.10/lm/search_hashed.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/search_trie.cc -o build/temp.linux-x86_64-3.10/lm/search_trie.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/sizes.cc -o build/temp.linux-x86_64-3.10/lm/sizes.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/trie.cc -o build/temp.linux-x86_64-3.10/lm/trie.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/trie_sort.cc -o build/temp.linux-x86_64-3.10/lm/trie_sort.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/value_build.cc -o build/temp.linux-x86_64-3.10/lm/value_build.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/virtual_interface.cc -o build/temp.linux-x86_64-3.10/lm/virtual_interface.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c lm/vocab.cc -o build/temp.linux-x86_64-3.10/lm/vocab.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/home/idris/.pyenv/versions/3.10.4/include/python3.10 -c python/kenlm.cpp -o build/temp.linux-x86_64-3.10/python/kenlm.o -O3 -DNDEBUG -DKENLM_MAX_ORDER=6 -std=c++11 -DHAVE_ZLIB -DHAVE_BZLIB -DHAVE_XZLIB
      python/kenlm.cpp: In function ‘PyObject* __Pyx_Coroutine_Send(PyObject*, PyObject*)’:
      python/kenlm.cpp:10162:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10162:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
                         _PyGen_yf
      python/kenlm.cpp:10167:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10167:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                         ^~~~~~~~~~~
                         _PyGen_yf
      python/kenlm.cpp: In function ‘PyObject* __Pyx_Generator_Next(PyObject*)’:
      python/kenlm.cpp:10251:19: error: ‘_PyGen_Send’ was not declared in this scope
                   ret = _PyGen_Send((PyGenObject*)yf, NULL);
                         ^~~~~~~~~~~
      python/kenlm.cpp:10251:19: note: suggested alternative: ‘_PyGen_yf’
                   ret = _PyGen_Send((PyGenObject*)yf, NULL);
                         ^~~~~~~~~~~
                         _PyGen_yf
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> pypi-kenlm

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/home/idris/.pyenv/versions/3.10.4/bin/python -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/__main__.py", line 4, in <module>
    main()
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/deep.py", line 99, in main
    install_from_config(pipeline_config_path)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/utils/pip_wrapper/pip_wrapper.py", line 71, in install_from_config
    install(r)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/utils/pip_wrapper/pip_wrapper.py", line 36, in install
    result = subprocess.check_call([sys.executable, '-m', 'pip', 'install',
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/idris/.pyenv/versions/3.10.4/bin/python', '-m', 'pip', 'install', 'pypi-kenlm==0.1.20210121']' returned non-zero exit status 1.
```

Using latest kenlm fixes the problem.