### PR TITLE
Fix collections.Iterable import to make in work on Python 3.10

### DIFF
--- a/deeppavlov/core/data/simple_vocab.py
+++ b/deeppavlov/core/data/simple_vocab.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Counter, defaultdict, Iterable
+from collections import Counter, defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from itertools import chain
 from logging import getLogger
 from typing import Optional, Tuple, List


### PR DESCRIPTION
The Iterable abstract class was removed from collections in Python 3.10. See the deprecation note in the 3.9 collections docs (https://docs.python.org/3.9/library/collections.html).

So `python -m deeppavlov interact levenshtein_corrector_ru -d`  fails:
```
2022-07-22 14:25:52.58 INFO in 'deeppavlov.core.data.utils'['utils'] at line 95: Downloading from http://files.deeppavlov.ai/deeppavlov_data/vocabs/russian_words_vocab.dict.gz?config=levenshtein_corrector_ru to /home/idris/.deeppavlov/downloads/russian_words_vocab.dict.gz
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10.7M/10.7M [00:01<00:00, 9.73MB/s]
2022-07-22 14:25:53.504 INFO in 'deeppavlov.core.data.utils'['utils'] at line 272: Extracting /home/idris/.deeppavlov/downloads/russian_words_vocab.dict.gz archive into /home/idris/.deeppavlov/downloads/vocabs
2022-07-22 14:25:53.983 INFO in 'deeppavlov.core.data.utils'['utils'] at line 95: Downloading from http://files.deeppavlov.ai/lang_models/ru_wiyalen_no_punkt.arpa.binary.gz?config=levenshtein_corrector_ru to /home/idris/.deeppavlov/downloads/ru_wiyalen_no_punkt.arpa.binary.gz
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.26G/3.26G [01:58<00:00, 27.4MB/s]
2022-07-22 14:27:53.143 INFO in 'deeppavlov.core.data.utils'['utils'] at line 272: Extracting /home/idris/.deeppavlov/downloads/ru_wiyalen_no_punkt.arpa.binary.gz archive into /home/idris/.deeppavlov/downloads/language_models
[nltk_data] Downloading package punkt to /home/idris/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
[nltk_data] Downloading package stopwords to /home/idris/nltk_data...
[nltk_data]   Unzipping corpora/stopwords.zip.
[nltk_data] Downloading package perluniprops to
[nltk_data]     /home/idris/nltk_data...
[nltk_data]   Package perluniprops is already up-to-date!
[nltk_data] Downloading package nonbreaking_prefixes to
[nltk_data]     /home/idris/nltk_data...
[nltk_data]   Package nonbreaking_prefixes is already up-to-date!
Traceback (most recent call last):
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/__main__.py", line 4, in <module>
    main()
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/deep.py", line 80, in main
    interact_model(pipeline_config_path)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/commands/infer.py", line 79, in interact_model
    model = build_model(config)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/commands/infer.py", line 62, in build_model
    component = from_params(component_config, mode=mode, serialized=component_serialized)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/common/params.py", line 95, in from_params
    obj = get_model(cls_name)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/common/registry.py", line 74, in get_model
    return cls_from_str(_REGISTRY[name])
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/common/registry.py", line 42, in cls_from_str
    return getattr(importlib.import_module(module_name), cls_name)
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/idris/.pyenv/versions/3.10.4/lib/python3.10/site-packages/deeppavlov/core/data/simple_vocab.py", line 15, in <module>
    from collections import Counter, defaultdict, Iterable
ImportError: cannot import name 'Iterable' from 'collections' (/home/idris/.pyenv/versions/3.10.4/lib/python3.10/collections/__init__.py)
``` 

Here is the fix to make it work on Python 3.10.