### PR TITLE
refactor: pytest version restricted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         extras_require={
             'tests': [
                 'flake8',
-                'pytest',
+                'pytest<7.2.0',
                 'pytest-instafail',
                 'pexpect'
             ],


### PR DESCRIPTION
Tests of the python 3.6 containers stuck. This PR is intended to fix this issue.