### PR TITLE
fix: pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ nltk>=3.2.4,<3.10.0
 numpy<1.24
 pandas>=1.0.0,<1.6.0
 prometheus-client>=0.13.0,<=1.16.0
-pydantic
+pydantic<2
 pybind11==2.10.3
 requests>=2.19.0,<3.0.0
 scikit-learn>=0.24,<1.1.0


### PR DESCRIPTION
Fix `ImportError: cannot import name 'Undefined' from 'pydantic.fields'` on pydantic>=2