### PR TITLE
Fixed KeyError regarding deeppavlov/vocabs/typos

### DIFF
--- a/deeppavlov/vocabs/typos.py
+++ b/deeppavlov/vocabs/typos.py
@@ -62,8 +62,10 @@ class StaticDictionary:
             words = {self._normalize(word) for word in words}
 
             alphabet = {c for w in words for c in w}
-            alphabet.remove('⟬')
-            alphabet.remove('⟭')
+            if '⟬' in alphabet:
+                alphabet.remove('⟬')
+            if '⟭' in alphabet:
+                alphabet.remove('⟭')
 
             save_pickle(alphabet, alphabet_path)
             save_pickle(words, words_path)


### PR DESCRIPTION
This is a fix to issue #1697.
In Issue #1697, this person talks about a KeyError when trying to use the configs.spelling_correction.brillmoore_wikitypos_en model, raising a KeyError when trying to get rid of the keys ⟬ and ⟭, which does not exist. I have tested, and the error wasn't raised (The model was downloaded and libraries were installed). I loaded the model normally, and output was clean and normal.
___________________________________________
from deeppavlov import configs, build_model

model = build_model(configs.spelling_correction.brillmoore_wikitypos_en,)
output = model(["Where is navada"])
print(output)

OUTPUT:
['where is nevada']
