### PR TITLE
fix: set columns and dtype explicitly in dataset readers

### DIFF
--- a/deeppavlov/dataset_readers/basic_classification_reader.py
+++ b/deeppavlov/dataset_readers/basic_classification_reader.py
@@ -78,11 +78,11 @@ class BasicClassificationDatasetReader(DatasetReader):
             file = Path(data_path).joinpath(file_name)
             if file.exists():
                 if format == 'csv':
-                    keys = ('sep', 'header', 'names')
+                    keys = ('sep', 'header', 'names', 'dtype')
                     options = {k: kwargs[k] for k in keys if k in kwargs}
                     df = pd.read_csv(file, **options)
                 elif format == 'json':
-                    keys = ('orient', 'lines')
+                    keys = ('orient', 'lines', 'dtype')
                     options = {k: kwargs[k] for k in keys if k in kwargs}
                     df = pd.read_json(file, **options)
                 else:

--- a/deeppavlov/dataset_readers/docred_reader.py
+++ b/deeppavlov/dataset_readers/docred_reader.py
@@ -409,6 +409,6 @@ class DocREDDatasetReader(DatasetReader):
     def print_statistics(self, train_stat: Dict, valid_stat: Dict, test_stat: Dict) -> None:
         """ Print out the relation statistics as a markdown table """
         df = pd.DataFrame([self.rel2relid, train_stat, valid_stat, test_stat]).T
-        df.columns = ['d{}'.format(i) for i, col in enumerate(df, 1)]
+        df.columns = ['rel_id', 'train', 'valid', 'test']
         logger.info("\n")
         logger.info(df)


### PR DESCRIPTION
Fixes #1654

  ## Changes
  - \`docred_reader.py\`: replaced generic \`d1, d2, d3, d4\` column names with \`rel_id\`, \`train\`, \`valid\`, \`test\`
  - \`basic_classification_reader.py\`: added \`dtype\` to the passthrough keys for both \`csv\` and \`json\` reads so callers can explicitly   
  control column types

  ## Code smell addressed
  Columns and DataType Not Explicitly Set — [Zhang et al., CAIN 2022](https://dl.acm.org/doi/abs/10.1145/3522664.3528620)