### PR TITLE
docs: fix environment spelling in docs

### DIFF
--- a/docs/integrations/aws_ec2.rst
+++ b/docs/integrations/aws_ec2.rst
@@ -99,7 +99,7 @@ Deployment process consists of two main stages:
 
     ``sudo pip3 install virtualenv``
 
-5.  Create and activate Python 3.6 virtual enviroment:
+5.  Create and activate Python 3.6 virtual environment:
 
     ``virtualenv env -p python3.6``
 


### PR DESCRIPTION
Changes:
- `enviroment` -> `environment` in `docs/integrations/aws_ec2.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked my prior PRs in this repository before opening this PR.
